### PR TITLE
fix: preserve remote image URLs in inference

### DIFF
--- a/inference/run_inference.py
+++ b/inference/run_inference.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from threading import Thread
 from typing import Any, Dict, Iterable, List
+from urllib.parse import urlparse
 
 import torch
 from transformers import AutoModelForCausalLM, AutoProcessor
@@ -433,6 +434,12 @@ def resolve_path(base_dir: Path, value: str) -> str:
     return str(path)
 
 
+def resolve_image_reference(base_dir: Path, value: str) -> str:
+    if urlparse(value).scheme.lower() in {"http", "https"}:
+        return value
+    return resolve_path(base_dir, value)
+
+
 def resolve_video_entry(base_dir: Path, value: Any) -> Any:
     if isinstance(value, str):
         return resolve_path(base_dir, value)
@@ -458,9 +465,9 @@ def resolve_message_content_media_paths(content: Any, base_dir: Path) -> Any:
         item_copy = dict(item)
         if item_copy.get("type") == "image" or "image" in item_copy or "image_url" in item_copy:
             if item_copy.get("image") is not None:
-                item_copy["image"] = resolve_path(base_dir, item_copy["image"])
+                item_copy["image"] = resolve_image_reference(base_dir, item_copy["image"])
             if item_copy.get("image_url") is not None:
-                item_copy["image_url"] = resolve_path(base_dir, item_copy["image_url"])
+                item_copy["image_url"] = resolve_image_reference(base_dir, item_copy["image_url"])
         elif item_copy.get("type") == "video" or "video" in item_copy:
             if item_copy.get("video") is not None:
                 item_copy["video"] = resolve_video_entry(base_dir, item_copy["video"])
@@ -470,7 +477,9 @@ def resolve_message_content_media_paths(content: Any, base_dir: Path) -> Any:
 
 def resolve_query_media_paths(query: Dict[str, Any], base_dir: Path) -> Dict[str, Any]:
     resolved = dict(query)
-    resolved["images"] = [resolve_path(base_dir, image) for image in query.get("images", [])]
+    resolved["images"] = [
+        resolve_image_reference(base_dir, image) for image in query.get("images", [])
+    ]
     resolved["videos"] = [resolve_video_entry(base_dir, video) for video in query.get("videos", [])]
     resolved["media_kwargs"] = dict(query.get("media_kwargs") or {})
     resolved["generate_kwargs"] = dict(query.get("generate_kwargs") or {})

--- a/inference/tests/test_run_inference.py
+++ b/inference/tests/test_run_inference.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+torch = types.ModuleType("torch")
+torch.bfloat16 = object()
+transformers = types.ModuleType("transformers")
+transformers.AutoModelForCausalLM = object()
+transformers.AutoProcessor = object()
+
+module_path = Path(__file__).resolve().parents[1] / "run_inference.py"
+module_spec = importlib.util.spec_from_file_location("run_inference", module_path)
+run_inference = importlib.util.module_from_spec(module_spec)
+with patch.dict(sys.modules, {"torch": torch, "transformers": transformers}):
+    module_spec.loader.exec_module(run_inference)
+resolve_query_media_paths = run_inference.resolve_query_media_paths
+
+
+class ResolveQueryMediaPathsTest(unittest.TestCase):
+    def test_preserves_remote_image_references(self):
+        image_url = "https://example.com/images/sample.jpg?size=large"
+        query = {
+            "images": [image_url],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image_url},
+                        {"type": "image", "image_url": image_url},
+                    ],
+                }
+            ],
+        }
+
+        resolved = resolve_query_media_paths(query, Path("/tmp/queries"))
+
+        self.assertEqual(resolved["images"], [image_url])
+        self.assertEqual(resolved["messages"][0]["content"][0]["image"], image_url)
+        self.assertEqual(
+            resolved["messages"][0]["content"][1]["image_url"], image_url
+        )
+
+    def test_resolves_local_image_references(self):
+        base_dir = Path("/tmp/queries")
+        absolute_image = "/data/images/absolute.jpg"
+        query = {
+            "images": ["images/relative.jpg", absolute_image],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": "images/inline.jpg"},
+                        {"type": "image", "image_url": "images/url-field.jpg"},
+                    ],
+                }
+            ],
+        }
+
+        resolved = resolve_query_media_paths(query, base_dir)
+
+        self.assertEqual(
+            resolved["images"],
+            [str((base_dir / "images/relative.jpg").resolve()), absolute_image],
+        )
+        self.assertEqual(
+            resolved["messages"][0]["content"][0]["image"],
+            str((base_dir / "images/inline.jpg").resolve()),
+        )
+        self.assertEqual(
+            resolved["messages"][0]["content"][1]["image_url"],
+            str((base_dir / "images/url-field.jpg").resolve()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Preserve HTTP and HTTPS image references instead of resolving them as local files.
- Keep existing relative and absolute local image path behavior unchanged.
- Add regression coverage for top-level images, inline image fields, and inline image_url fields.

## Why

The inference path resolver passed every image reference through pathlib.Path. Remote URLs were therefore rewritten into invalid local paths such as /input/https:/example.com/image.jpg before reaching the processor.

## Validation

- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s inference/tests -v
- uvx ruff check inference/run_inference.py inference/tests/test_run_inference.py
- git diff --check