### PR TITLE
fix: normalize image URL content type

### DIFF
--- a/inference/run_inference.py
+++ b/inference/run_inference.py
@@ -463,6 +463,8 @@ def resolve_message_content_media_paths(content: Any, base_dir: Path) -> Any:
             continue
 
         item_copy = dict(item)
+        if item_copy.get("type") == "image_url":
+            item_copy["type"] = "image"
         if item_copy.get("type") == "image" or "image" in item_copy or "image_url" in item_copy:
             if item_copy.get("image") is not None:
                 item_copy["image"] = resolve_image_reference(base_dir, item_copy["image"])

--- a/inference/tests/test_run_inference.py
+++ b/inference/tests/test_run_inference.py
@@ -21,6 +21,26 @@ resolve_query_media_paths = run_inference.resolve_query_media_paths
 
 
 class ResolveQueryMediaPathsTest(unittest.TestCase):
+    def test_normalizes_image_url_content_type_for_model(self):
+        image_url = "https://example.com/images/sample.jpg"
+        query = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": image_url},
+                    ],
+                }
+            ],
+        }
+
+        resolved = resolve_query_media_paths(query, Path("/tmp/queries"))
+
+        self.assertEqual(
+            resolved["messages"][0]["content"][0],
+            {"type": "image", "image_url": image_url},
+        )
+
     def test_preserves_remote_image_references(self):
         image_url = "https://example.com/images/sample.jpg?size=large"
         query = {


### PR DESCRIPTION
## What changed

- Normalize message content items from `type: "image_url"` to the model-supported `type: "image"` before offline inference.
- Preserve the existing `image_url` value and remote/local path handling.
- Add regression coverage for the normalized model input.

## Why

The inference wrapper treated `type: "image_url"` content as image input, but the model only emits an image token for `type: "image"` or items with an `image` field. As a result, an `image_url` item could reach the model without a vision token and silently run as text-only inference.

## Validation

- `python3 -m unittest inference.tests.test_run_inference`
- `uvx ruff check inference/run_inference.py inference/tests/test_run_inference.py`
- `git diff --check`
