### PR TITLE
feat(fa3): add an Ampere-only build mode

### DIFF
--- a/flash-attention-src/README.md
+++ b/flash-attention-src/README.md
@@ -184,20 +184,22 @@ features here.
 
 ## Requirements
 
-This specialized version is developed and validated for FA3 training on NVIDIA
-Hopper GPUs.
+This specialized version is developed for MOSS-VL training, with its operators
+validated on NVIDIA Ampere and Hopper GPUs.
 
-- NVIDIA H100, H800, or H200 class GPU
+- NVIDIA A100 or A800 (SM80), or H100, H800, or H200 (SM90)
 - CUDA 12.3 or newer
 - CUDA 12.8 recommended
 - PyTorch with CUDA support
 - `packaging`, `psutil`, `ninja`, and `einops`
 - Linux
 
-The current validation environment uses an NVIDIA H200, CUDA 12.8, and PyTorch
-2.8. With PyTorch versions below 2.9, `hopper/setup.py` builds
-`flash_api.cpp`. PyTorch 2.9 or newer selects `flash_api_stable.cpp`; that stable
-ABI build path should be validated separately in a PyTorch 2.9+ environment.
+SM80 supports FP16 and BF16 with matching Q/K/V head dimensions. FP8, `q_v`,
+and different Q/K and V head dimensions remain Hopper-only.
+
+The operator validation environments include H200 with CUDA 12.8 and PyTorch
+2.8, and A800 80GB with CUDA 13.0 and PyTorch 2.11. PyTorch versions below 2.9
+build `flash_api.cpp`; PyTorch 2.9 or newer selects `flash_api_stable.cpp`.
 
 ## Build and Installation
 
@@ -209,6 +211,19 @@ Build the extension in place for development:
 cd hopper
 MAX_JOBS=8 python setup.py build_ext --inplace
 ```
+
+An architecture-specific build can omit kernels for the other GPU family:
+
+```bash
+# Ampere/Ada only. This also disables Hopper-only FP8 kernels.
+FLASH_ATTENTION_DISABLE_SM90=TRUE MAX_JOBS=8 python setup.py build_ext --inplace
+
+# Hopper only.
+FLASH_ATTENTION_DISABLE_SM80=TRUE MAX_JOBS=8 python setup.py build_ext --inplace
+```
+
+`FLASH_ATTENTION_DISABLE_SM80` and `FLASH_ATTENTION_DISABLE_SM90` cannot both
+be enabled.
 
 Or install the specialized FA3 package into the active environment:
 
@@ -245,7 +260,8 @@ pytest -q \
 The focused suite covers API compatibility, forward/backward numerical parity,
 non-monotonic boundaries, fully masked rows, variable-length inputs, packed QKV,
 GQA, KV-cache execution, scheduler metadata, package exports, and mask
-reconstruction. The current suite contains 261 tests.
+reconstruction. The current suite contains 265 tests. On SM80, 9
+SM90-specific regression tests are skipped.
 
 Run the MOSS-VL-shaped parity utility with:
 

--- a/flash-attention-src/hopper/flash_api.cpp
+++ b/flash-attention-src/hopper/flash_api.cpp
@@ -46,6 +46,20 @@ inline at::cuda::CUDAGuard make_cuda_guard_from_tensor(const at::Tensor& t) {
   return at::cuda::CUDAGuard(static_cast<c10::DeviceIndex>(t.get_device()));
 }
 
+inline void check_supported_arch(int major) {
+#ifdef FLASHATTENTION_DISABLE_SM8x
+    TORCH_CHECK(major == 9,
+                "This FlashAttention build was compiled with FLASH_ATTENTION_DISABLE_SM80=TRUE "
+                "and only supports Hopper GPUs (SM90).");
+#elif defined(FLASHATTENTION_DISABLE_SM90)
+    TORCH_CHECK(major == 8,
+                "This FlashAttention build was compiled with FLASH_ATTENTION_DISABLE_SM90=TRUE "
+                "and only supports Ampere/Ada GPUs (SM8x).");
+#else
+    TORCH_CHECK(major >= 8, "FlashAttention only supports Ampere GPUs or newer.");
+#endif
+}
+
 inline void check_cross_kv_boundary(
         const at::Tensor& cross_kv_boundary,
         bool is_varlen_q,
@@ -569,6 +583,10 @@ mha_fwd_get_scheduler_metadata(
         int64_t sm_margin,
         std::optional<at::Tensor> cross_kv_boundary_) {
 
+    auto device_guard = make_cuda_guard_from_tensor(seqused_k);
+    auto dprops = at::cuda::getCurrentDeviceProperties();
+    check_supported_arch(dprops->major);
+
     TORCH_CHECK(qkv_dtype == at::ScalarType::Half || qkv_dtype == at::ScalarType::BFloat16 || qkv_dtype == at::ScalarType::Float8_e4m3fn,
                 "FlashAttention only supports fp16, bf16, and fp8_e4m3 data type");
     TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -632,8 +650,8 @@ mha_fwd_get_scheduler_metadata(
             params.window_size_right = 0;
         }
     }
-    params.arch = at::cuda::getCurrentDeviceProperties()->major * 10 + at::cuda::getCurrentDeviceProperties()->minor;
-    params.num_sm = at::cuda::getCurrentDeviceProperties()->multiProcessorCount - sm_margin;
+    params.arch = dprops->major * 10 + dprops->minor;
+    params.num_sm = dprops->multiProcessorCount - sm_margin;
     params.softcap = has_softcap ? 1.0f : 0.0f;
 
     params.page_size = page_size.has_value() ? page_size.value() : 1;
@@ -649,10 +667,6 @@ mha_fwd_get_scheduler_metadata(
     params.pack_gqa = pack_gqa_.has_value() ? pack_gqa_.value() : get_pack_gqa(params);
 
     bool is_varlen = true;
-
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_cuda_guard_from_tensor(seqused_k);
 
     auto opts = seqused_k.options();
     // This needs to be set after get_num_splits
@@ -745,9 +759,9 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
         std::optional<at::Tensor> cross_kv_boundary_  // (b, s_q) or (total_q,). Per-query KV boundary for staircase mask.
         ) {
 
+    auto device_guard = make_cuda_guard_from_tensor(q);
     auto dprops = at::cuda::getCurrentDeviceProperties();
-    bool is_sm8x = dprops->major >= 8;
-    TORCH_CHECK(is_sm8x, "FlashAttention only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto q_type = q.scalar_type();
     TORCH_CHECK(q_type == at::ScalarType::Half || q_type == at::ScalarType::BFloat16 || q_type == at::ScalarType::Float8_e4m3fn,
@@ -923,10 +937,6 @@ mha_fwd(at::Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seql
     int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdimv(head_size_v);
     int const seqlen_q_rounded = round_multiple(seqlen_q, 128);
     int const seqlen_k_rounded = round_multiple(seqlen_k, 128);
-
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_cuda_guard_from_tensor(q);
 
     at::Tensor softmax_lse;
     if (!is_varlen_q) {
@@ -1348,9 +1358,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
         TORCH_CHECK(false, "This flash attention build does not support backward.");
     #endif
 
+    auto device_guard = make_cuda_guard_from_tensor(q);
     auto dprops = at::cuda::getCurrentDeviceProperties();
-    bool is_sm8x = dprops->major >= 8;
-    TORCH_CHECK(is_sm8x, "FlashAttention only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto q_type = q.dtype();
     TORCH_CHECK(q_type == torch::kFloat16 || q_type == torch::kBFloat16,
@@ -1527,10 +1537,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor> mha_bwd(
         dv = torch::empty_like(v);
     }
 
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_cuda_guard_from_tensor(q);
-
     auto opts = q.options();
     // Need softmax_d to have total_q_padded_rounded since we want its address to be aligned by 16/8 bytes for TMA / LDG.64
     at::Tensor softmax_d, softmax_lse_log2;
@@ -1644,9 +1650,9 @@ mha_combine(at::Tensor out_partial,         // num_splits x batch_size x seqlen 
             std::optional<at::ScalarType> out_dtype_
             ) {
 
+    auto device_guard = make_cuda_guard_from_tensor(out_partial);
     auto dprops = at::cuda::getCurrentDeviceProperties();
-    bool is_sm8x = dprops->major >= 8;
-    TORCH_CHECK(is_sm8x, "Attention combine function only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto out_partial_type = out_partial.scalar_type();
     TORCH_CHECK(out_partial_type == at::ScalarType::Float, "Attention combine function only support fp32 data type");
@@ -1696,10 +1702,6 @@ mha_combine(at::Tensor out_partial,         // num_splits x batch_size x seqlen 
         out = torch::empty({batch_size, seqlen, num_heads, head_size}, opts.dtype(out_type));
     }
 
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    at::cuda::CUDAGuard device_guard{(char)out_partial.get_device()};
-
     auto softmax_lse = torch::empty({batch_size, num_heads, seqlen}, opts.dtype(at::kFloat)).transpose(1, 2);
 
     Flash_fwd_params params {};  // Need to reset the params to set everything to zero
@@ -1724,7 +1726,7 @@ mha_combine(at::Tensor out_partial,         // num_splits x batch_size x seqlen 
     params.o_row_stride = out.stride(1);
     params.o_head_stride = out.stride(2);
     params.o_batch_stride = out.stride(0);
-    params.arch = at::cuda::getCurrentDeviceProperties()->major * 10 + at::cuda::getCurrentDeviceProperties()->minor;
+    params.arch = dprops->major * 10 + dprops->minor;
 
     if (seqlen > 0 && batch_size > 0) {
         auto stream = at::cuda::getCurrentCUDAStream().stream();

--- a/flash-attention-src/hopper/flash_api_stable.cpp
+++ b/flash-attention-src/hopper/flash_api_stable.cpp
@@ -76,6 +76,20 @@ cudaDeviceProp* get_device_prop() {
   std::call_once(device_flags[device_index], initDeviceProperty, device_index);
   return &device_properties[device_index];
 }
+
+inline void check_supported_arch(int major) {
+#ifdef FLASHATTENTION_DISABLE_SM8x
+    STD_TORCH_CHECK(major == 9,
+                    "This FlashAttention build was compiled with FLASH_ATTENTION_DISABLE_SM80=TRUE "
+                    "and only supports Hopper GPUs (SM90).");
+#elif defined(FLASHATTENTION_DISABLE_SM90)
+    STD_TORCH_CHECK(major == 8,
+                    "This FlashAttention build was compiled with FLASH_ATTENTION_DISABLE_SM90=TRUE "
+                    "and only supports Ampere/Ada GPUs (SM8x).");
+#else
+    STD_TORCH_CHECK(major >= 8, "FlashAttention only supports Ampere GPUs or newer.");
+#endif
+}
 } // anonymous namespace
 
 
@@ -637,6 +651,10 @@ mha_fwd_get_scheduler_metadata(
         int64_t sm_margin,
         std::optional<Tensor> cross_kv_boundary_) {
 
+    auto device_guard = make_device_guard(seqused_k);
+    auto dprops = get_device_prop();
+    check_supported_arch(dprops->major);
+
     STD_TORCH_CHECK(qkv_dtype == torch::headeronly::ScalarType::Half || qkv_dtype == torch::headeronly::ScalarType::BFloat16 || qkv_dtype == torch::headeronly::ScalarType::Float8_e4m3fn,
                 "FlashAttention only supports fp16, bf16, and fp8_e4m3 data type");
     STD_TORCH_CHECK(num_heads % num_heads_k == 0, "Number of heads in key/value must divide number of heads in query");
@@ -700,7 +718,6 @@ mha_fwd_get_scheduler_metadata(
             params.window_size_right = 0;
         }
     }
-    auto dprops = get_device_prop();
     params.arch = dprops->major * 10 + dprops->minor;
     params.num_sm = dprops->multiProcessorCount - sm_margin;
     params.softcap = has_softcap ? 1.0f : 0.0f;
@@ -718,10 +735,6 @@ mha_fwd_get_scheduler_metadata(
     params.pack_gqa = pack_gqa_.has_value() ? pack_gqa_.value() : get_pack_gqa(params);
 
     bool is_varlen = true;
-
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_device_guard(seqused_k);
 
     // This needs to be set after get_num_splits
     Tensor tile_count_semaphore;  // Contains the semaphore and optionally num_splits_dynamic
@@ -817,9 +830,9 @@ mha_fwd(Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_
         std::optional<Tensor> cross_kv_boundary_  // (b, s_q) or (total_q,). Per-query KV boundary for staircase mask.
         ) {
 
+    auto device_guard = make_device_guard(q);
     auto dprops = get_device_prop();
-    bool is_sm8x = dprops->major >= 8;
-    STD_TORCH_CHECK(is_sm8x, "FlashAttention only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto q_type = q.scalar_type();
     STD_TORCH_CHECK(q_type == torch::headeronly::ScalarType::Half || q_type == torch::headeronly::ScalarType::BFloat16 || q_type == torch::headeronly::ScalarType::Float8_e4m3fn,
@@ -987,10 +1000,6 @@ mha_fwd(Tensor q,   // (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_
     int const head_size_v_rounded = head_size_v == head_size ? head_size_rounded : round_up_headdimv(head_size_v);
     int const seqlen_q_rounded = round_multiple(seqlen_q, 128);
     int const seqlen_k_rounded = round_multiple(seqlen_k, 128);
-
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_device_guard(q);
 
     Tensor softmax_lse;
     if (!is_varlen_q) {
@@ -1419,9 +1428,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> mha_bwd(
         STD_TORCH_CHECK(false, "This flash attention build does not support backward.");
     #endif
 
+    auto device_guard = make_device_guard(q);
     auto dprops = get_device_prop();
-    bool is_sm8x = dprops->major >= 8;
-    STD_TORCH_CHECK(is_sm8x, "FlashAttention only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto q_type = q.scalar_type();
     STD_TORCH_CHECK(q_type == torch::headeronly::ScalarType::Half || q_type == torch::headeronly::ScalarType::BFloat16,
@@ -1598,10 +1607,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> mha_bwd(
         dv = torch::stable::empty_like(v);
     }
 
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_device_guard(q);
-
     // auto opts = q.options();
     // Need softmax_d to have total_q_padded_rounded since we want its address to be aligned by 16/8 bytes for TMA / LDG.64
     Tensor softmax_d, softmax_lse_log2;
@@ -1722,9 +1727,9 @@ mha_combine(Tensor out_partial,         // num_splits x batch_size x seqlen x nu
             std::optional<torch::headeronly::ScalarType> out_dtype_
             ) {
 
+    auto device_guard = make_device_guard(out_partial);
     auto dprops = get_device_prop();
-    bool is_sm8x = dprops->major >= 8;
-    STD_TORCH_CHECK(is_sm8x, "Attention combine function only supports Ampere GPUs or newer.");
+    check_supported_arch(dprops->major);
 
     auto out_partial_type = out_partial.scalar_type();
     STD_TORCH_CHECK(out_partial_type == torch::headeronly::ScalarType::Float, "Attention combine function only support fp32 data type");
@@ -1773,10 +1778,6 @@ mha_combine(Tensor out_partial,         // num_splits x batch_size x seqlen x nu
     } else {
         out = torch::stable::new_empty(out_partial, {batch_size, seqlen, num_heads, head_size}, std::make_optional(out_type));
     }
-
-    // Otherwise the kernel will be launched from cuda:0 device
-    // Cast to char to avoid compiler warning about narrowing
-    auto device_guard = make_device_guard(out_partial);
 
     auto softmax_lse = torch::stable::new_empty(out_partial, {batch_size, num_heads, seqlen}, std::make_optional(torch::headeronly::ScalarType::Float));
     softmax_lse = torch::stable::transpose(softmax_lse, 1, 2);

--- a/flash-attention-src/hopper/setup.py
+++ b/flash-attention-src/hopper/setup.py
@@ -65,6 +65,14 @@ DISABLE_HDIM128 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM128", "FALSE") == "TRUE
 DISABLE_HDIM192 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM192", "FALSE") == "TRUE"
 DISABLE_HDIM256 = os.getenv("FLASH_ATTENTION_DISABLE_HDIM256", "FALSE") == "TRUE"
 DISABLE_SM8x = os.getenv("FLASH_ATTENTION_DISABLE_SM80", "FALSE") == "TRUE"
+DISABLE_SM90 = os.getenv("FLASH_ATTENTION_DISABLE_SM90", "FALSE") == "TRUE"
+
+if DISABLE_SM8x and DISABLE_SM90:
+    raise RuntimeError(
+        "FLASH_ATTENTION_DISABLE_SM80 and FLASH_ATTENTION_DISABLE_SM90 cannot both be TRUE"
+    )
+if DISABLE_SM90:
+    DISABLE_FP8 = True
 
 ENABLE_VCOLMAJOR = os.getenv("FLASH_ATTENTION_ENABLE_VCOLMAJOR", "FALSE") == "TRUE"
 
@@ -106,6 +114,7 @@ def create_build_config_file():
             "FLASHATTENTION_DISABLE_HDIM192": DISABLE_HDIM192,
             "FLASHATTENTION_DISABLE_HDIM256": DISABLE_HDIM256,
             "FLASHATTENTION_DISABLE_SM8x": DISABLE_SM8x,
+            "FLASHATTENTION_DISABLE_SM90": DISABLE_SM90,
             "FLASHATTENTION_ENABLE_VCOLMAJOR": ENABLE_VCOLMAJOR,
             "FLASH_ATTENTION_DISABLE_HDIMDIFF64": DISABLE_HDIMDIFF64,
             "FLASH_ATTENTION_DISABLE_HDIMDIFF192": DISABLE_HDIMDIFF192,
@@ -251,7 +260,12 @@ def _write_ninja_file(path,
             elif source_file.endswith('_sm100.cu'):
                 rule = 'cuda_compile_sm100'
             else:
-                rule = 'cuda_compile_sm80_sm90'
+                if DISABLE_SM90:
+                    rule = 'cuda_compile_sm80'
+                elif DISABLE_SM8x:
+                    rule = 'cuda_compile'
+                else:
+                    rule = 'cuda_compile_sm80_sm90'
         else:
             rule = 'compile'
         if IS_WINDOWS:
@@ -530,6 +544,7 @@ if not SKIP_CUDA_BUILD:
         + (["-DFLASHATTENTION_DISABLE_HDIM192"] if DISABLE_HDIM192 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIM256"] if DISABLE_HDIM256 else [])
         + (["-DFLASHATTENTION_DISABLE_SM8x"] if DISABLE_SM8x else [])
+        + (["-DFLASHATTENTION_DISABLE_SM90"] if DISABLE_SM90 else [])
         + (["-DFLASHATTENTION_ENABLE_VCOLMAJOR"] if ENABLE_VCOLMAJOR else [])
         + (["-DFLASHATTENTION_DISABLE_HDIMDIFF64"] if DISABLE_HDIMDIFF64 else [])
         + (["-DFLASHATTENTION_DISABLE_HDIMDIFF192"] if DISABLE_HDIMDIFF192 else [])
@@ -601,8 +616,10 @@ if not SKIP_CUDA_BUILD:
 
     sources = (
         [flash_api_source]
-        + (sources_fwd_sm80 if not DISABLE_SM8x else []) + sources_fwd_sm90
-        + (sources_bwd_sm80 if not DISABLE_SM8x else []) + sources_bwd_sm90
+        + (sources_fwd_sm80 if not DISABLE_SM8x else [])
+        + (sources_fwd_sm90 if not DISABLE_SM90 else [])
+        + (sources_bwd_sm80 if not DISABLE_SM8x else [])
+        + (sources_bwd_sm90 if not DISABLE_SM90 else [])
     )
     if not DISABLE_SPLIT:
         sources += ["flash_fwd_combine.cu"]

--- a/flash-attention-src/hopper/static_switch.h
+++ b/flash-attention-src/hopper/static_switch.h
@@ -128,11 +128,24 @@
   #define CLUSTER_SWITCH BOOL_SWITCH
 #endif
 
-#ifdef FLASHATTENTION_DISABLE_SM8x
+#if defined(FLASHATTENTION_DISABLE_SM8x) && defined(FLASHATTENTION_DISABLE_SM90)
+  #error "FLASHATTENTION_DISABLE_SM8x and FLASHATTENTION_DISABLE_SM90 cannot both be defined"
+#elif defined(FLASHATTENTION_DISABLE_SM8x)
   #define ARCH_SWITCH(ARCH, ARCH_NAME, ...)                                                      \
   [&] {                                                                                          \
     constexpr static int ARCH_NAME = 90;                                                         \
     return __VA_ARGS__();                                                                        \
+  }()
+#elif defined(FLASHATTENTION_DISABLE_SM90)
+  #define ARCH_SWITCH(ARCH, ARCH_NAME, ...)                                                      \
+  [&] {                                                                                          \
+    if (ARCH == 86 || ARCH == 89) {                                                              \
+      constexpr static int ARCH_NAME = 86;                                                       \
+      return __VA_ARGS__();                                                                      \
+    } else {                                                                                     \
+      constexpr static int ARCH_NAME = 80;                                                       \
+      return __VA_ARGS__();                                                                      \
+    }                                                                                            \
   }()
 #else
   #define ARCH_SWITCH(ARCH, ARCH_NAME, ...)                                                      \

--- a/flash-attention-src/hopper/test_kvcache_cross_kv_boundary.py
+++ b/flash-attention-src/hopper/test_kvcache_cross_kv_boundary.py
@@ -94,19 +94,29 @@ def _kvcache_out(*args, **kwargs):
 
 
 @pytest.mark.parametrize("pack_gqa", [False, True])
-def test_kvcache_cross_kv_boundary_no_append_metadata_packgqa(pack_gqa):
+@pytest.mark.parametrize(
+    "dtype, headdim, num_splits",
+    [
+        pytest.param(torch.bfloat16, 64, 2, id="bf16-hdim64-split2"),
+        pytest.param(torch.bfloat16, 128, 0, id="bf16-hdim128-auto"),
+        pytest.param(torch.float16, 128, 1, id="fp16-hdim128-single"),
+    ],
+)
+def test_kvcache_cross_kv_boundary_no_append_metadata_packgqa(
+    dtype, headdim, num_splits, pack_gqa
+):
     torch.manual_seed(0)
-    batch, seqlen_q, seqlen_k, nheads_k, gqa, headdim = 2, 5, 16, 2, 2, 64
+    batch, seqlen_q, seqlen_k, nheads_k, gqa = 2, 5, 16, 2, 2
     nheads_q = nheads_k * gqa
-    q = torch.randn(batch, seqlen_q, nheads_q, headdim, device="cuda", dtype=torch.bfloat16)
-    k_cache = torch.randn(batch, seqlen_k, nheads_k, headdim, device="cuda", dtype=torch.bfloat16)
-    v_cache = torch.randn(batch, seqlen_k, nheads_k, headdim, device="cuda", dtype=torch.bfloat16)
+    q = torch.randn(batch, seqlen_q, nheads_q, headdim, device="cuda", dtype=dtype)
+    k_cache = torch.randn(batch, seqlen_k, nheads_k, headdim, device="cuda", dtype=dtype)
+    v_cache = torch.randn(batch, seqlen_k, nheads_k, headdim, device="cuda", dtype=dtype)
     cache_seqlens = torch.tensor([11, 8], device="cuda", dtype=torch.int32)
     cross_kv_boundary = torch.tensor([[0, 3, 7, 11, 5], [2, 6, 0, 8, 4]], device="cuda", dtype=torch.int32)
 
     k_ref, v_ref = _logical_cache(k_cache, v_cache, cache_seqlens)
     out_ref = _boundary_attention_ref(q, k_ref, v_ref, cross_kv_boundary)
-    metadata = _metadata_for(q, k_cache, cache_seqlens, cross_kv_boundary, num_splits=2, pack_gqa=pack_gqa)
+    metadata = _metadata_for(q, k_cache, cache_seqlens, cross_kv_boundary, num_splits=num_splits, pack_gqa=pack_gqa)
 
     for scheduler_metadata in [None, metadata]:
         out = _kvcache_out(
@@ -116,7 +126,7 @@ def test_kvcache_cross_kv_boundary_no_append_metadata_packgqa(pack_gqa):
             cache_seqlens=cache_seqlens,
             cross_kv_boundary=cross_kv_boundary,
             scheduler_metadata=scheduler_metadata,
-            num_splits=2,
+            num_splits=num_splits,
             pack_gqa=pack_gqa,
             return_softmax_lse=True,
         )

--- a/flash-attention-src/hopper/test_staircase_mask.py
+++ b/flash-attention-src/hopper/test_staircase_mask.py
@@ -884,6 +884,7 @@ def test_staircase_mask_mossvl_multivideo_right_padding_precision(dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_staircase_constant_boundary_matches_no_mask(dtype):
     """When cross_kv_boundary is all seqlen_k, output should match unmasked attention."""
+    torch.manual_seed(0)
     batch_size = 2
     seqlen_q = 128
     seqlen_k = 128
@@ -903,7 +904,8 @@ def test_staircase_constant_boundary_matches_no_mask(dtype):
     )
     out_no_mask = flash_attn_func(q, k, v, causal=False)
 
-    torch.testing.assert_close(out_staircase, out_no_mask, atol=1e-3, rtol=1e-3)
+    tol = max(1e-3, torch.finfo(dtype).eps)
+    torch.testing.assert_close(out_staircase, out_no_mask, atol=tol, rtol=tol)
 
 
 def test_staircase_causal_raises():


### PR DESCRIPTION
## Summary

The FA3 backend already works on A100/A800, but its build always compiles Hopper kernels too. This adds `FLASH_ATTENTION_DISABLE_SM90=TRUE` for an SM80-only build. The default SM80+SM90 build is unchanged.

The new mode skips SM90 forward and backward kernels, compiles shared CUDA sources for SM80 only, and disables FP8 because this backend only provides FP8 kernels for SM90. It also rejects conflicting architecture flags and reports a clear error if an architecture-specific build is loaded on the wrong GPU.

SM80 KV-cache coverage now includes head dim 128, automatic and single split, FP16, and BF16. The BF16 full-boundary test uses the dtype epsilon to account for the different SM80 tile and reduction order; no kernel code changed.

## Validation

NVIDIA A800-SXM4-80GB, CUDA 13.0, PyTorch 2.11:

- `256 passed, 9 skipped`
- The SM80-only artifact contained 22 SM80 cubins and no SM90 cubins. With the same focused feature set, its size dropped from 223 MB to 96 MB.
- MOSS-VL-shaped FP16 and BF16 forward and backward parity passed, with zero masked probability leakage.
- The wrong-architecture guard was verified with an SM90-only build.
- `python3 -m py_compile` and `git diff --check` passed.
