### PR TITLE
feat: expose cross-attention backend override

### DIFF
--- a/finetune/README.md
+++ b/finetune/README.md
@@ -189,6 +189,12 @@ python finetune/train.py \
   --report_to none
 ```
 
+Cross-attention keeps its existing default unless an override is provided. To
+use the repository's specialized FA3 kernel for cross-attention only, first
+[install the kernel](../flash-attention-src/README.md#build-and-installation),
+then add `--cross_attention_implementation flash_attention_3` to the training
+command.
+
 ## Key Arguments
 
 ### ModelArguments
@@ -196,6 +202,7 @@ python finetune/train.py \
 | Argument | Default | Description |
 |---|---|---|
 | `--model_name_or_path` | (required) | Path to the MOSS-VL checkpoint |
+| `--cross_attention_implementation` | `None` | Optional cross-attention backend override |
 | `--tune_vision` | `False` | Train the vision encoder |
 | `--tune_language` | `True` | Train the language model layers |
 | `--tune_lm_head` | `True` | Train the LM head projection |

--- a/finetune/arguments.py
+++ b/finetune/arguments.py
@@ -9,6 +9,10 @@ class ModelArguments:
     model_name_or_path: str = field(
         metadata={"help": "Path to the MOSS-VL checkpoint directory."},
     )
+    cross_attention_implementation: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional cross-attention backend override."},
+    )
     tune_vision: bool = field(
         default=False,
         metadata={"help": "Whether to train the vision encoder."},

--- a/finetune/tests/test_train.py
+++ b/finetune/tests/test_train.py
@@ -1,0 +1,96 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+finetune_dir = Path(__file__).resolve().parents[1]
+
+torch = types.ModuleType("torch")
+torch.Tensor = object()
+torch.bfloat16 = object()
+torch.cuda = SimpleNamespace(synchronize=MagicMock())
+
+transformers = types.ModuleType("transformers")
+transformers.TrainingArguments = object
+transformers.AutoModelForCausalLM = object()
+transformers.AutoProcessor = object()
+transformers.Trainer = object()
+transformers.HfArgumentParser = object()
+
+arguments_path = finetune_dir / "arguments.py"
+arguments_spec = importlib.util.spec_from_file_location("arguments", arguments_path)
+arguments = importlib.util.module_from_spec(arguments_spec)
+
+data = types.ModuleType("data")
+data.MossVLSFTDataset = object()
+data.MossVLDataCollator = object()
+
+with patch.dict(
+    sys.modules,
+    {
+        "torch": torch,
+        "transformers": transformers,
+        "arguments": arguments,
+        "data": data,
+    },
+):
+    arguments_spec.loader.exec_module(arguments)
+    train_path = finetune_dir / "train.py"
+    train_spec = importlib.util.spec_from_file_location("moss_vl_train", train_path)
+    train = importlib.util.module_from_spec(train_spec)
+    sys.modules["moss_vl_train"] = train
+    train_spec.loader.exec_module(train)
+
+
+class StopAfterModelLoad(Exception):
+    pass
+
+
+class TrainModelLoadTest(unittest.TestCase):
+    def run_until_model_load(self, cross_attention_implementation):
+        model_args = arguments.ModelArguments(
+            model_name_or_path="checkpoint",
+            cross_attention_implementation=cross_attention_implementation,
+        )
+        parser = MagicMock()
+        parser.parse_args_into_dataclasses.return_value = (
+            model_args,
+            SimpleNamespace(),
+            SimpleNamespace(local_rank=-1),
+        )
+        processor = MagicMock()
+        model_loader = MagicMock()
+        model_loader.from_pretrained.side_effect = StopAfterModelLoad
+
+        with (
+            patch.object(train.transformers, "HfArgumentParser", return_value=parser),
+            patch.object(train, "AutoProcessor") as processor_loader,
+            patch.object(train, "AutoModelForCausalLM", model_loader),
+            self.assertRaises(StopAfterModelLoad),
+        ):
+            processor_loader.from_pretrained.return_value = processor
+            train.train()
+
+        return model_loader.from_pretrained.call_args.kwargs
+
+    def test_default_does_not_pass_cross_attention_override(self):
+        kwargs = self.run_until_model_load(None)
+
+        self.assertEqual(kwargs["attn_implementation"], "flash_attention_2")
+        self.assertNotIn("cross_attention_implementation", kwargs)
+
+    def test_explicit_cross_attention_override_is_forwarded(self):
+        kwargs = self.run_until_model_load("flash_attention_3")
+
+        self.assertEqual(
+            kwargs["cross_attention_implementation"],
+            "flash_attention_3",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/finetune/train.py
+++ b/finetune/train.py
@@ -98,11 +98,18 @@ def train() -> None:
     processor.tokenizer.padding_side = "right"
 
     # ---- Model -------------------------------------------------------
+    model_kwargs = {
+        "trust_remote_code": True,
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+    }
+    if model_args.cross_attention_implementation is not None:
+        model_kwargs["cross_attention_implementation"] = (
+            model_args.cross_attention_implementation
+        )
     model = AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
-        trust_remote_code=True,
-        torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
+        **model_kwargs,
     )
     model.config.use_cache = False
 

--- a/inference/README.md
+++ b/inference/README.md
@@ -62,6 +62,15 @@ python inference/run_inference.py \
 
 If `--output` is omitted, the script writes results to `<input_stem>_results.json`.
 
+Cross-attention keeps its existing default unless an override is provided. To
+use the repository's specialized FA3 kernel for cross-attention only, first
+[install the kernel](../flash-attention-src/README.md#build-and-installation),
+then add:
+
+```bash
+--cross-attention-implementation flash_attention_3
+```
+
 ## Input Format
 
 The input file can be either:

--- a/inference/run_inference.py
+++ b/inference/run_inference.py
@@ -89,22 +89,32 @@ def parse_args() -> argparse.Namespace:
         default=300.0,
         help="Timeout per query while waiting for offline_generate to finish.",
     )
+    parser.add_argument(
+        "--cross-attention-implementation",
+        default=None,
+        help="Optional cross-attention backend override provided by the checkpoint.",
+    )
     return parser.parse_args()
 
 
-def load_model(checkpoint: str):
+def load_model(
+    checkpoint: str,
+    cross_attention_implementation: str | None = None,
+):
     processor = AutoProcessor.from_pretrained(
         checkpoint,
         trust_remote_code=True,
         frame_extract_num_threads=1,
     )
-    model = AutoModelForCausalLM.from_pretrained(
-        checkpoint,
-        trust_remote_code=True,
-        device_map="auto",
-        torch_dtype=torch.bfloat16,
-        attn_implementation="flash_attention_2",
-    )
+    model_kwargs = {
+        "trust_remote_code": True,
+        "device_map": "auto",
+        "torch_dtype": torch.bfloat16,
+        "attn_implementation": "flash_attention_2",
+    }
+    if cross_attention_implementation is not None:
+        model_kwargs["cross_attention_implementation"] = cross_attention_implementation
+    model = AutoModelForCausalLM.from_pretrained(checkpoint, **model_kwargs)
     return model, processor
 
 
@@ -690,7 +700,10 @@ def main() -> None:
     )
 
     queries = load_queries(input_path)
-    model, processor = load_model(checkpoint)
+    model, processor = load_model(
+        checkpoint,
+        cross_attention_implementation=args.cross_attention_implementation,
+    )
     output = run_queries_via_offline_generate(
         model,
         processor,

--- a/inference/tests/test_run_inference.py
+++ b/inference/tests/test_run_inference.py
@@ -3,7 +3,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 torch = types.ModuleType("torch")
@@ -18,6 +18,41 @@ run_inference = importlib.util.module_from_spec(module_spec)
 with patch.dict(sys.modules, {"torch": torch, "transformers": transformers}):
     module_spec.loader.exec_module(run_inference)
 resolve_query_media_paths = run_inference.resolve_query_media_paths
+
+
+class LoadModelTest(unittest.TestCase):
+    def test_default_does_not_pass_cross_attention_override(self):
+        processor_loader = MagicMock()
+        model_loader = MagicMock()
+
+        with (
+            patch.object(run_inference, "AutoProcessor", processor_loader),
+            patch.object(run_inference, "AutoModelForCausalLM", model_loader),
+        ):
+            run_inference.load_model("checkpoint")
+
+        kwargs = model_loader.from_pretrained.call_args.kwargs
+        self.assertEqual(kwargs["attn_implementation"], "flash_attention_2")
+        self.assertNotIn("cross_attention_implementation", kwargs)
+
+    def test_explicit_cross_attention_override_is_forwarded(self):
+        processor_loader = MagicMock()
+        model_loader = MagicMock()
+
+        with (
+            patch.object(run_inference, "AutoProcessor", processor_loader),
+            patch.object(run_inference, "AutoModelForCausalLM", model_loader),
+        ):
+            run_inference.load_model(
+                "checkpoint",
+                cross_attention_implementation="flash_attention_3",
+            )
+
+        kwargs = model_loader.from_pretrained.call_args.kwargs
+        self.assertEqual(
+            kwargs["cross_attention_implementation"],
+            "flash_attention_3",
+        )
 
 
 class ResolveQueryMediaPathsTest(unittest.TestCase):


### PR DESCRIPTION
This exposes the checkpoint optional cross-attention backend in the existing inference and fine-tuning entry points.

The new flags are forwarded only when set, so the current FA2 configuration and default behavior stay unchanged. Setting the override to `flash_attention_3` selects the boundary-aware cross-attention path from [the checkpoint PR](https://huggingface.co/OpenMOSS-Team/MOSS-VL-Instruct-0708/discussions/4), while self-attention remains on the existing backend.

Tested:
- 5 inference unit tests
- 2 fine-tuning unit tests
- targeted Ruff checks
- A800 80GB with MOSS-VL 11B: two-image prefill, four cached decode steps, and 16-token `generate()`; the FA3 path avoided dense mask expansion and matched the SDPA reference at every checked greedy token

The A800 kernel build used #16.